### PR TITLE
Issue #1 header line count and overrides

### DIFF
--- a/src/main/java/com/github/ansell/csv/stream/CSVStream.java
+++ b/src/main/java/com/github/ansell/csv/stream/CSVStream.java
@@ -55,6 +55,8 @@ import com.fasterxml.jackson.dataformat.csv.CsvSchema.ColumnType;
  */
 public final class CSVStream {
 
+	public static final int DEFAULT_HEADER_COUNT = 1;
+	
 	/**
 	 * Private constructor for static only class
 	 */
@@ -125,6 +127,84 @@ public final class CSVStream {
 	public static <T> void parse(final Reader reader, final Consumer<List<String>> headersValidator,
 			final BiFunction<List<String>, List<String>, T> lineConverter, final Consumer<T> resultConsumer)
 			throws IOException, CSVStreamException {
+				parse(reader, headersValidator, lineConverter, resultConsumer, null);
+			}
+
+	/**
+	 * Stream a CSV file from the given Reader through the header validator,
+	 * line checker, and if the line checker succeeds, send the
+	 * checked/converted line to the consumer.
+	 * 
+	 * @param reader
+	 *            The {@link Reader} containing the CSV file.
+	 * @param headersValidator
+	 *            The validator of the header line. Throwing
+	 *            IllegalArgumentException or other RuntimeExceptions causes the
+	 *            parsing process to short-circuit after parsing the header
+	 *            line, with a CSVStreamException being rethrown by this code.
+	 * @param lineConverter
+	 *            The validator and converter of lines, based on the header
+	 *            line. If the lineChecker returns null, the line will not be
+	 *            passed to the writer.
+	 * @param resultConsumer
+	 *            The consumer of the checked lines.
+	 * @param substituteHeaders A substitute set of headers or null to use the headers from the file. If this is null the first line of the file will be used.
+	 * @param <T>
+	 *            The type of the results that will be created by the
+	 *            lineChecker and pushed into the writer {@link Consumer}.
+	 * @throws IOException
+	 *             If an error occurred accessing the input.
+	 * @throws CSVStreamException
+	 *             If an error occurred validating the input.
+	 */
+	public static <T> void parse(final Reader reader, final Consumer<List<String>> headersValidator,
+			final BiFunction<List<String>, List<String>, T> lineConverter, final Consumer<T> resultConsumer, 
+			final List<String> substituteHeaders)
+			throws IOException, CSVStreamException {
+				parse(reader, headersValidator, lineConverter, resultConsumer, substituteHeaders, DEFAULT_HEADER_COUNT);
+			}
+
+	/**
+	 * Stream a CSV file from the given Reader through the header validator,
+	 * line checker, and if the line checker succeeds, send the
+	 * checked/converted line to the consumer.
+	 * 
+	 * @param reader
+	 *            The {@link Reader} containing the CSV file.
+	 * @param headersValidator
+	 *            The validator of the header line. Throwing
+	 *            IllegalArgumentException or other RuntimeExceptions causes the
+	 *            parsing process to short-circuit after parsing the header
+	 *            line, with a CSVStreamException being rethrown by this code.
+	 * @param lineConverter
+	 *            The validator and converter of lines, based on the header
+	 *            line. If the lineChecker returns null, the line will not be
+	 *            passed to the writer.
+	 * @param resultConsumer
+	 *            The consumer of the checked lines.
+	 * @param substituteHeaders A substitute set of headers or null to use the headers from the file. If this is null and headerLineCount is set to 0, an IllegalArgumentException ill be thrown.
+	 * @param headerLineCount The number of header lines to expect
+	 * @param <T>
+	 *            The type of the results that will be created by the
+	 *            lineChecker and pushed into the writer {@link Consumer}.
+	 * @throws IOException
+	 *             If an error occurred accessing the input.
+	 * @throws CSVStreamException
+	 *             If an error occurred validating the input.
+	 */
+	public static <T> void parse(final Reader reader, final Consumer<List<String>> headersValidator,
+			final BiFunction<List<String>, List<String>, T> lineConverter, final Consumer<T> resultConsumer, 
+			final List<String> substituteHeaders, int headerLineCount)
+			throws IOException, CSVStreamException {
+		
+		if(headerLineCount < 0) {
+			throw new IllegalArgumentException("Header line count must be non-negative.");
+		}
+		
+		if(headerLineCount < 1 && substituteHeaders == null) {
+			throw new IllegalArgumentException("If there are no header lines, a substitute set of headers must be defined.");
+		}
+		
 		final CsvMapper mapper = new CsvMapper();
 		mapper.enable(CsvParser.Feature.TRIM_SPACES);
 		mapper.enable(CsvParser.Feature.WRAP_AS_ARRAY);

--- a/src/main/java/com/github/ansell/csv/stream/CSVStream.java
+++ b/src/main/java/com/github/ansell/csv/stream/CSVStream.java
@@ -231,7 +231,7 @@ public final class CSVStream {
 					} catch (final Exception e) {
 						throw new CSVStreamException("Could not verify headers for csv file", e);
 					}
-				} else if (lineCount <= headerLineCount) {
+				} else if (lineCount >= headerLineCount) {
 					if (nextLine.size() != headers.size()) {
 						throw new CSVStreamException(
 								"Line and header sizes were different: " + headers + " " + nextLine);

--- a/src/main/java/com/github/ansell/csv/stream/CSVStream.java
+++ b/src/main/java/com/github/ansell/csv/stream/CSVStream.java
@@ -216,7 +216,7 @@ public final class CSVStream {
 			try {
 				headersValidator.accept(headers);
 			} catch (final Exception e) {
-				throw new CSVStreamException("Could not verify headers for csv file", e);
+				throw new CSVStreamException("Could not verify substituted headers for csv file", e);
 			}
 		}
 		

--- a/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
+++ b/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
@@ -503,4 +503,36 @@ public class CSVStreamTest {
 		assertFalse("Too many lines", lineError.get());
 	}
 
+	/**
+	 * Test method for
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
+	 * .
+	 */
+	@Test
+	public final void testStreamCSVThreeHeadersNoSubstitutes() throws Exception {
+		
+		AtomicBoolean headersGood = new AtomicBoolean(false);
+		AtomicBoolean lineGood = new AtomicBoolean(false);
+		AtomicBoolean foundLine = new AtomicBoolean(false);
+		AtomicBoolean lineError = new AtomicBoolean(false);
+		CSVStream.parse(new StringReader("TestHeader1\nTestShouldDefinitelyNotSeeThisHeader2\nYetAnotherHiddenHeader3\nTestValue1"), h -> {
+			if (h.size() == 1 && h.contains("TestHeader1")) {
+				headersGood.set(true);
+			}
+		}, (h, l) -> {
+			if (foundLine.compareAndSet(false, true) && l.size() == 1 && l.contains("TestValue1")) {
+				lineGood.set(true);
+			} else {
+				lineError.set(true);
+			}
+			return l;
+		}, l -> {
+		}, null, 3);
+
+		assertTrue("Headers were not recognised", headersGood.get());
+		assertTrue("Line was not recognised", lineGood.get());
+		assertTrue("Line was not found", foundLine.get());
+		assertFalse("Too many lines", lineError.get());
+	}
+
 }

--- a/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
+++ b/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
@@ -471,4 +471,36 @@ public class CSVStreamTest {
 		assertFalse("Too many lines", lineError.get());
 	}
 
+	/**
+	 * Test method for
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
+	 * .
+	 */
+	@Test
+	public final void testStreamCSVZeroHeadersWithSubstitutesOverridingMultipleValid() throws Exception {
+		
+		AtomicBoolean headersGood = new AtomicBoolean(false);
+		AtomicBoolean lineGood = new AtomicBoolean(false);
+		AtomicBoolean foundLine = new AtomicBoolean(false);
+		AtomicBoolean lineError = new AtomicBoolean(false);
+		CSVStream.parse(new StringReader("TestShouldNotSeeThisHeader1\nTestShouldDefinitelyNotSeeThisHeader2\nYetAnotherHiddenHeader3\nTestValue1"), h -> {
+			if (h.size() == 1 && h.contains("TestHeader1")) {
+				headersGood.set(true);
+			}
+		}, (h, l) -> {
+			if (foundLine.compareAndSet(false, true) && l.size() == 1 && l.contains("TestValue1")) {
+				lineGood.set(true);
+			} else {
+				lineError.set(true);
+			}
+			return l;
+		}, l -> {
+		}, Arrays.asList("TestHeader1"), 3);
+
+		assertTrue("Headers were not recognised", headersGood.get());
+		assertTrue("Line was not recognised", lineGood.get());
+		assertTrue("Line was not found", foundLine.get());
+		assertFalse("Too many lines", lineError.get());
+	}
+
 }

--- a/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
+++ b/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
@@ -419,6 +419,36 @@ public class CSVStreamTest {
 	 * .
 	 */
 	@Test
+	public final void testStreamCSVFailSubstitutedHeaderValidation() throws Exception {
+		thrown.expect(CSVStreamException.class);
+		thrown.expectMessage("Could not verify substituted headers for csv file");
+		CSVStream.parse(new StringReader("TestHeaderWhichShouldNotBeSeen"), h -> { 
+			throw new RuntimeException("Testing failure of validation for substituted headers: " + h.toString());
+		}, (h, l) -> l, l -> {
+		}, Arrays.asList("TestSubstitutedHeader"), 0);
+	}
+
+	/**
+	 * Test method for
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
+	 * .
+	 */
+	@Test
+	public final void testStreamCSVFailSubstitutedHeaderValidationOther() throws Exception {
+		thrown.expect(CSVStreamException.class);
+		thrown.expectMessage("Could not verify substituted headers for csv file");
+		CSVStream.parse(new StringReader("TestHeaderWhichShouldNotBeSeen"), h -> { 
+			throw new RuntimeException("Testing failure of validation for substituted headers: " + h.toString());
+		}, (h, l) -> l, l -> {
+		}, Arrays.asList("TestSubstitutedHeader"), 1);
+	}
+
+	/**
+	 * Test method for
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
+	 * .
+	 */
+	@Test
 	public final void testStreamCSVZeroHeadersWithSubstitutesValid() throws Exception {
 		
 		AtomicBoolean headersGood = new AtomicBoolean(false);

--- a/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
+++ b/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
@@ -439,4 +439,36 @@ public class CSVStreamTest {
 		assertTrue("Line was not recognised", lineGood.get());
 	}
 
+	/**
+	 * Test method for
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
+	 * .
+	 */
+	@Test
+	public final void testStreamCSVZeroHeadersWithSubstitutesOverrideValid() throws Exception {
+		
+		AtomicBoolean headersGood = new AtomicBoolean(false);
+		AtomicBoolean lineGood = new AtomicBoolean(false);
+		AtomicBoolean foundLine = new AtomicBoolean(false);
+		AtomicBoolean lineError = new AtomicBoolean(false);
+		CSVStream.parse(new StringReader("TestShouldNotSeeThisHeader1\nTestValue1"), h -> {
+			if (h.size() == 1 && h.contains("TestHeader1")) {
+				headersGood.set(true);
+			}
+		}, (h, l) -> {
+			if (foundLine.compareAndSet(false, true) && l.size() == 1 && l.contains("TestValue1")) {
+				lineGood.set(true);
+			} else {
+				lineError.set(true);
+			}
+			return l;
+		}, l -> {
+		}, Arrays.asList("TestHeader1"), 1);
+
+		assertTrue("Headers were not recognised", headersGood.get());
+		assertTrue("Line was not recognised", lineGood.get());
+		assertTrue("Line was not found", foundLine.get());
+		assertFalse("Too many lines", lineError.get());
+	}
+
 }

--- a/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
+++ b/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
@@ -413,4 +413,30 @@ public class CSVStreamTest {
 		}, null, 0);
 	}
 
+	/**
+	 * Test method for
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
+	 * .
+	 */
+	@Test
+	public final void testStreamCSVZeroHeadersWithSubstitutesValid() throws Exception {
+		
+		AtomicBoolean headersGood = new AtomicBoolean(false);
+		AtomicBoolean lineGood = new AtomicBoolean(false);
+		CSVStream.parse(new StringReader("TestValue1"), h -> {
+			if (h.size() == 1 && h.contains("TestHeader1")) {
+				headersGood.set(true);
+			}
+		}, (h, l) -> {
+			if (l.size() == 1 && l.contains("TestValue1")) {
+				lineGood.set(true);
+			}
+			return l;
+		}, l -> {
+		}, Arrays.asList("TestHeader1"), 0);
+
+		assertTrue("Headers were not recognised", headersGood.get());
+		assertTrue("Line was not recognised", lineGood.get());
+	}
+
 }

--- a/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
+++ b/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
@@ -60,7 +60,7 @@ public class CSVStreamTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
 	 * .
 	 */
 	@Test
@@ -75,7 +75,7 @@ public class CSVStreamTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.InputStream, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.InputStream, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
 	 * .
 	 */
 	@Test
@@ -90,7 +90,7 @@ public class CSVStreamTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.InputStream, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.InputStream, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
 	 * .
 	 */
 	@Test
@@ -104,7 +104,7 @@ public class CSVStreamTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
 	 * .
 	 */
 	@Test
@@ -119,7 +119,7 @@ public class CSVStreamTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
 	 * .
 	 */
 	@Test
@@ -133,7 +133,7 @@ public class CSVStreamTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
 	 * .
 	 */
 	@Test
@@ -147,7 +147,7 @@ public class CSVStreamTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
 	 * .
 	 */
 	@Test
@@ -163,7 +163,7 @@ public class CSVStreamTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
 	 * .
 	 */
 	@Test
@@ -182,7 +182,7 @@ public class CSVStreamTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
 	 * .
 	 */
 	@Test
@@ -199,7 +199,7 @@ public class CSVStreamTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
 	 * .
 	 */
 	@Test
@@ -219,7 +219,7 @@ public class CSVStreamTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
 	 * .
 	 */
 	@Test
@@ -239,7 +239,7 @@ public class CSVStreamTest {
 
 	/**
 	 * Test method for
-	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer)}
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
 	 * .
 	 */
 	@Test
@@ -383,6 +383,34 @@ public class CSVStreamTest {
 			return o;
 		});
 		fail("Should not have successfully written the document. Output was: " + writer.toString());
+	}
+
+	/**
+	 * Test method for
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
+	 * .
+	 */
+	@Test
+	public final void testStreamCSVNegativeHeaderCount() throws Exception {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("Header line count must be non-negative.");
+		CSVStream.parse(new StringReader("Test"), h -> {
+		}, (h, l) -> l, l -> {
+		}, null, -1);
+	}
+
+	/**
+	 * Test method for
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
+	 * .
+	 */
+	@Test
+	public final void testStreamCSVZeroHeadersNoSubstitutes() throws Exception {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage("If there are no header lines, a substitute set of headers must be defined.");
+		CSVStream.parse(new StringReader("Test"), h -> {
+		}, (h, l) -> l, l -> {
+		}, null, 0);
 	}
 
 }


### PR DESCRIPTION
Allows configurable selection of expected header line counts, along with substitution in both the cases where they exist and they don't.