### PR TITLE
Fix #3 Allow users to define escape, quote, and column characters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,9 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<jackson.version>2.8.7</jackson.version>
+		<jackson.version>2.8.8</jackson.version>
 		<junit.version>4.12</junit.version>
-		<slf4j.version>1.7.21</slf4j.version>
+		<slf4j.version>1.7.25</slf4j.version>
 	</properties>
 	<prerequisites>
 		<maven>3.0.5</maven>
@@ -113,7 +113,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.5.1</version>
+					<version>3.6.1</version>
 					<configuration>
 						<source>1.8</source>
 						<target>1.8</target>
@@ -132,7 +132,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>3.0.1</version>
+					<version>3.0.2</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -183,12 +183,12 @@
 				<plugin>
 					<groupId>org.jacoco</groupId>
 					<artifactId>jacoco-maven-plugin</artifactId>
-					<version>0.7.7.201606060606</version>
+					<version>0.7.9</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.19.1</version>
+					<version>2.20</version>
 					<configuration>
 						<!-- Travis build workaround, see https://github.com/travis-ci/travis-ci/issues/3396 -->
 						<argLine>${argLine} -Xmx1024m</argLine>
@@ -197,13 +197,13 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>appassembler-maven-plugin</artifactId>
-					<version>1.10</version>
+					<version>2.0.0</version>
 				</plugin>
 				<!-- Create code coverage reports and submit them to coveralls.io. -->
 				<plugin>
 					<groupId>org.eluder.coveralls</groupId>
 					<artifactId>coveralls-maven-plugin</artifactId>
-					<version>4.2.0</version>
+					<version>4.3.0</version>
 				</plugin>
 				<!--This plugin's configuration is used to store Eclipse m2e settings 
 					only. It has no influence on the Maven build itself. -->

--- a/src/main/java/com/github/ansell/csv/stream/CSVStream.java
+++ b/src/main/java/com/github/ansell/csv/stream/CSVStream.java
@@ -57,7 +57,7 @@ import com.fasterxml.jackson.dataformat.csv.CsvSchema.ColumnType;
 public final class CSVStream {
 
 	public static final int DEFAULT_HEADER_COUNT = 1;
-	
+
 	/**
 	 * Private constructor for static only class
 	 */
@@ -128,8 +128,8 @@ public final class CSVStream {
 	public static <T> void parse(final Reader reader, final Consumer<List<String>> headersValidator,
 			final BiFunction<List<String>, List<String>, T> lineConverter, final Consumer<T> resultConsumer)
 			throws IOException, CSVStreamException {
-				parse(reader, headersValidator, lineConverter, resultConsumer, null);
-			}
+		parse(reader, headersValidator, lineConverter, resultConsumer, null);
+	}
 
 	/**
 	 * Stream a CSV file from the given Reader through the header validator,
@@ -149,7 +149,10 @@ public final class CSVStream {
 	 *            passed to the writer.
 	 * @param resultConsumer
 	 *            The consumer of the checked lines.
-	 * @param substituteHeaders A substitute set of headers or null to use the headers from the file. If this is null the first line of the file will be used.
+	 * @param substituteHeaders
+	 *            A substitute set of headers or null to use the headers from
+	 *            the file. If this is null the first line of the file will be
+	 *            used.
 	 * @param <T>
 	 *            The type of the results that will be created by the
 	 *            lineChecker and pushed into the writer {@link Consumer}.
@@ -159,11 +162,10 @@ public final class CSVStream {
 	 *             If an error occurred validating the input.
 	 */
 	public static <T> void parse(final Reader reader, final Consumer<List<String>> headersValidator,
-			final BiFunction<List<String>, List<String>, T> lineConverter, final Consumer<T> resultConsumer, 
-			final List<String> substituteHeaders)
-			throws IOException, CSVStreamException {
-				parse(reader, headersValidator, lineConverter, resultConsumer, substituteHeaders, DEFAULT_HEADER_COUNT);
-			}
+			final BiFunction<List<String>, List<String>, T> lineConverter, final Consumer<T> resultConsumer,
+			final List<String> substituteHeaders) throws IOException, CSVStreamException {
+		parse(reader, headersValidator, lineConverter, resultConsumer, substituteHeaders, DEFAULT_HEADER_COUNT);
+	}
 
 	/**
 	 * Stream a CSV file from the given Reader through the header validator,
@@ -183,8 +185,12 @@ public final class CSVStream {
 	 *            passed to the writer.
 	 * @param resultConsumer
 	 *            The consumer of the checked lines.
-	 * @param substituteHeaders A substitute set of headers or null to use the headers from the file. If this is null and headerLineCount is set to 0, an IllegalArgumentException ill be thrown.
-	 * @param headerLineCount The number of header lines to expect
+	 * @param substituteHeaders
+	 *            A substitute set of headers or null to use the headers from
+	 *            the file. If this is null and headerLineCount is set to 0, an
+	 *            IllegalArgumentException ill be thrown.
+	 * @param headerLineCount
+	 *            The number of header lines to expect
 	 * @param <T>
 	 *            The type of the results that will be created by the
 	 *            lineChecker and pushed into the writer {@link Consumer}.
@@ -194,17 +200,13 @@ public final class CSVStream {
 	 *             If an error occurred validating the input.
 	 */
 	public static <T> void parse(final Reader reader, final Consumer<List<String>> headersValidator,
-			final BiFunction<List<String>, List<String>, T> lineConverter, final Consumer<T> resultConsumer, 
-			final List<String> substituteHeaders, int headerLineCount)
-			throws IOException, CSVStreamException {
-		final CsvMapper mapper = new CsvMapper();
-		mapper.enable(CsvParser.Feature.TRIM_SPACES);
-		mapper.enable(CsvParser.Feature.WRAP_AS_ARRAY);
-		mapper.configure(JsonParser.Feature.ALLOW_YAML_COMMENTS, true);
-		
+			final BiFunction<List<String>, List<String>, T> lineConverter, final Consumer<T> resultConsumer,
+			final List<String> substituteHeaders, int headerLineCount) throws IOException, CSVStreamException {
+		final CsvMapper mapper = defaultMapper();
+
 		parse(reader, headersValidator, lineConverter, resultConsumer, substituteHeaders, headerLineCount, mapper);
 	}
-	
+
 	/**
 	 * Stream a CSV file from the given Reader through the header validator,
 	 * line checker, and if the line checker succeeds, send the
@@ -223,8 +225,12 @@ public final class CSVStream {
 	 *            passed to the writer.
 	 * @param resultConsumer
 	 *            The consumer of the checked lines.
-	 * @param substituteHeaders A substitute set of headers or null to use the headers from the file. If this is null and headerLineCount is set to 0, an IllegalArgumentException ill be thrown.
-	 * @param headerLineCount The number of header lines to expect
+	 * @param substituteHeaders
+	 *            A substitute set of headers or null to use the headers from
+	 *            the file. If this is null and headerLineCount is set to 0, an
+	 *            IllegalArgumentException ill be thrown.
+	 * @param headerLineCount
+	 *            The number of header lines to expect
 	 * @param <T>
 	 *            The type of the results that will be created by the
 	 *            lineChecker and pushed into the writer {@link Consumer}.
@@ -234,28 +240,29 @@ public final class CSVStream {
 	 *             If an error occurred validating the input.
 	 */
 	public static <T> void parse(final Reader reader, final Consumer<List<String>> headersValidator,
-			final BiFunction<List<String>, List<String>, T> lineConverter, final Consumer<T> resultConsumer, 
+			final BiFunction<List<String>, List<String>, T> lineConverter, final Consumer<T> resultConsumer,
 			final List<String> substituteHeaders, int headerLineCount, CsvMapper mapper)
 			throws IOException, CSVStreamException {
-		
-		if(headerLineCount < 0) {
+
+		if (headerLineCount < 0) {
 			throw new IllegalArgumentException("Header line count must be non-negative.");
 		}
-		
-		if(headerLineCount < 1 && substituteHeaders == null) {
-			throw new IllegalArgumentException("If there are no header lines, a substitute set of headers must be defined.");
+
+		if (headerLineCount < 1 && substituteHeaders == null) {
+			throw new IllegalArgumentException(
+					"If there are no header lines, a substitute set of headers must be defined.");
 		}
-		
+
 		List<String> headers = substituteHeaders;
 
-		if(headers != null) {
+		if (headers != null) {
 			try {
 				headersValidator.accept(headers);
 			} catch (final Exception e) {
 				throw new CSVStreamException("Could not verify substituted headers for csv file", e);
 			}
 		}
-		
+
 		int lineCount = 0;
 		try (final MappingIterator<List<String>> it = mapper.readerFor(List.class).readValues(reader);) {
 			while (it.hasNext()) {
@@ -394,7 +401,7 @@ public final class CSVStream {
 	 *             {@link OutputStream}.
 	 */
 	public static SequenceWriter newCSVWriter(final OutputStream outputStream, CsvSchema schema) throws IOException {
-		return new CsvMapper().writerWithDefaultPrettyPrinter().with(schema).forType(List.class)
+		return defaultMapper().writerWithDefaultPrettyPrinter().with(schema).forType(List.class)
 				.writeValues(outputStream);
 	}
 
@@ -435,7 +442,7 @@ public final class CSVStream {
 	 *             {@link Writer}.
 	 */
 	public static SequenceWriter newCSVWriter(final Writer writer, CsvSchema schema) throws IOException {
-		return new CsvMapper().writerWithDefaultPrettyPrinter().with(schema).forType(List.class).writeValues(writer);
+		return defaultMapper().writerWithDefaultPrettyPrinter().with(schema).forType(List.class).writeValues(writer);
 	}
 
 	/**
@@ -447,6 +454,21 @@ public final class CSVStream {
 	 */
 	public static CsvSchema buildSchema(List<String> headers) {
 		return CsvSchema.builder().addColumns(headers, ColumnType.STRING).setUseHeader(true).build();
+	}
+
+	/**
+	 * Returns a {@link CsvMapper} that contains the default settings used by
+	 * csvstream.
+	 * 
+	 * @return A new {@link CsvMapper} setup to match the defaults used by
+	 *         csvstream
+	 */
+	public static CsvMapper defaultMapper() {
+		final CsvMapper mapper = new CsvMapper();
+		mapper.enable(CsvParser.Feature.TRIM_SPACES);
+		mapper.enable(CsvParser.Feature.WRAP_AS_ARRAY);
+		mapper.configure(JsonParser.Feature.ALLOW_YAML_COMMENTS, true);
+		return mapper;
 	}
 
 }

--- a/src/main/java/com/github/ansell/csv/stream/CSVStream.java
+++ b/src/main/java/com/github/ansell/csv/stream/CSVStream.java
@@ -203,8 +203,9 @@ public final class CSVStream {
 			final BiFunction<List<String>, List<String>, T> lineConverter, final Consumer<T> resultConsumer,
 			final List<String> substituteHeaders, int headerLineCount) throws IOException, CSVStreamException {
 		final CsvMapper mapper = defaultMapper();
+		final CsvSchema schema = CsvSchema.emptySchema();
 
-		parse(reader, headersValidator, lineConverter, resultConsumer, substituteHeaders, headerLineCount, mapper);
+		parse(reader, headersValidator, lineConverter, resultConsumer, substituteHeaders, headerLineCount, mapper, schema);
 	}
 
 	/**
@@ -241,7 +242,7 @@ public final class CSVStream {
 	 */
 	public static <T> void parse(final Reader reader, final Consumer<List<String>> headersValidator,
 			final BiFunction<List<String>, List<String>, T> lineConverter, final Consumer<T> resultConsumer,
-			final List<String> substituteHeaders, int headerLineCount, CsvMapper mapper)
+			final List<String> substituteHeaders, int headerLineCount, CsvMapper mapper, CsvSchema schema)
 			throws IOException, CSVStreamException {
 
 		if (headerLineCount < 0) {
@@ -264,7 +265,7 @@ public final class CSVStream {
 		}
 
 		int lineCount = 0;
-		try (final MappingIterator<List<String>> it = mapper.readerFor(List.class).readValues(reader);) {
+		try (final MappingIterator<List<String>> it = mapper.readerFor(List.class).with(schema).readValues(reader);) {
 			while (it.hasNext()) {
 				List<String> nextLine = it.next();
 				if (headers == null) {

--- a/src/main/java/com/github/ansell/csv/stream/CSVStream.java
+++ b/src/main/java/com/github/ansell/csv/stream/CSVStream.java
@@ -203,9 +203,10 @@ public final class CSVStream {
 			final BiFunction<List<String>, List<String>, T> lineConverter, final Consumer<T> resultConsumer,
 			final List<String> substituteHeaders, int headerLineCount) throws IOException, CSVStreamException {
 		final CsvMapper mapper = defaultMapper();
-		final CsvSchema schema = CsvSchema.emptySchema();
+		final CsvSchema schema = defaultSchema();
 
-		parse(reader, headersValidator, lineConverter, resultConsumer, substituteHeaders, headerLineCount, mapper, schema);
+		parse(reader, headersValidator, lineConverter, resultConsumer, substituteHeaders, headerLineCount, mapper,
+				schema);
 	}
 
 	/**
@@ -470,6 +471,17 @@ public final class CSVStream {
 		mapper.enable(CsvParser.Feature.WRAP_AS_ARRAY);
 		mapper.configure(JsonParser.Feature.ALLOW_YAML_COMMENTS, true);
 		return mapper;
+	}
+
+	/**
+	 * Returns a {@link CsvSchema} that contains the default settings used by
+	 * csvstream.
+	 * 
+	 * @return A new {@link CsvSchema} setup to match the defaults used by
+	 *         csvstream
+	 */
+	public static CsvSchema defaultSchema() {
+		return CsvSchema.emptySchema();
 	}
 
 }

--- a/src/main/java/com/github/ansell/csv/stream/CSVStream.java
+++ b/src/main/java/com/github/ansell/csv/stream/CSVStream.java
@@ -33,6 +33,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -281,6 +282,34 @@ public final class CSVStream {
 	 */
 	public static <T> void write(final Writer writer, final Stream<T> objects, final List<String> headers,
 			final BiFunction<List<String>, T, List<String>> objectConverter) throws IOException, CSVStreamException {
+		write(writer, objects, buildSchema(headers), objectConverter);
+	}
+
+	/**
+	 * Writes objects from the given {@link Stream} to the given {@link Writer}
+	 * in CSV format, converting them to a {@link List} of String's using the
+	 * given {@link BiFunction}.
+	 * 
+	 * @param writer
+	 *            The Writer that will receive the CSV file.
+	 * @param objects
+	 *            The Stream of objects to be written
+	 * @param schema
+	 *            The {@link CsvSchema} to use for the resulting CSV file.
+	 * @param objectConverter
+	 *            The function to convert an individual object to a line in the
+	 *            resulting CSV file, represented as a List of String's.
+	 * @param <T>
+	 *            The type of the objects to be converted.
+	 * @throws IOException
+	 *             If an error occurred accessing the output stream.
+	 * @throws CSVStreamException
+	 *             If an error occurred converting or serialising the objects.
+	 */
+	public static <T> void write(final Writer writer, final Stream<T> objects, final CsvSchema schema,
+			final BiFunction<List<String>, T, List<String>> objectConverter) throws IOException, CSVStreamException {
+		List<String> headers = new ArrayList<>();
+		schema.iterator().forEachRemaining(c -> headers.add(c.getName()));
 		try (SequenceWriter csvWriter = newCSVWriter(writer, headers);) {
 			objects.forEachOrdered(o -> {
 				try {

--- a/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
+++ b/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
@@ -597,4 +597,37 @@ public class CSVStreamTest {
 		assertFalse("Too many lines", lineError.get());
 	}
 
+
+	/**
+	 * Test method for
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
+	 * .
+	 */
+	@Test
+	public final void testStreamCSVUnescapedNewLineRFC4180Header() throws Exception {
+		
+		AtomicBoolean headersGood = new AtomicBoolean(false);
+		AtomicBoolean lineGood = new AtomicBoolean(false);
+		AtomicBoolean foundLine = new AtomicBoolean(false);
+		AtomicBoolean lineError = new AtomicBoolean(false);
+		CSVStream.parse(new StringReader("\"Test\nHeader1\"\n\"TestValue1\""), h -> {
+			if (h.size() == 1 && h.contains("Test\nHeader1")) {
+				headersGood.set(true);
+			}
+		}, (h, l) -> {
+			if (foundLine.compareAndSet(false, true) && l.size() == 1 && l.contains("TestValue1")) {
+				lineGood.set(true);
+			} else {
+				lineError.set(true);
+			}
+			return l;
+		}, l -> {
+		}, null, 1);
+
+		assertTrue("Headers were not recognised", headersGood.get());
+		assertTrue("Line was not recognised", lineGood.get());
+		assertTrue("Line was not found", foundLine.get());
+		assertFalse("Too many lines", lineError.get());
+	}
+
 }

--- a/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
+++ b/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
@@ -697,4 +697,39 @@ public class CSVStreamTest {
 		assertFalse("Too many lines", lineError.get());
 	}
 
+	/**
+	 * Test method for
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
+	 * .
+	 */
+	@Test
+	public final void testStreamCSVComment() throws Exception {
+		
+		AtomicBoolean headersGood = new AtomicBoolean(false);
+		AtomicBoolean lineGood = new AtomicBoolean(false);
+		AtomicBoolean foundLine = new AtomicBoolean(false);
+		AtomicBoolean lineError = new AtomicBoolean(false);
+		// The default mapper skips comment lines
+		CsvMapper mapper = CSVStream.defaultMapper();
+		CsvSchema schema = CsvSchema.builder().setQuoteChar('\'').build();
+		CSVStream.parse(new StringReader("'Test''\nHeader1'\n#A Comment that should be skipped\n'TestValue1'"), h -> {
+			if (h.size() == 1 && h.contains("Test'\nHeader1")) {
+				headersGood.set(true);
+			}
+		}, (h, l) -> {
+			if (foundLine.compareAndSet(false, true) && l.size() == 1 && l.contains("TestValue1")) {
+				lineGood.set(true);
+			} else {
+				lineError.set(true);
+			}
+			return l;
+		}, l -> {
+		}, null, 1, mapper, schema);
+
+		assertTrue("Headers were not recognised", headersGood.get());
+		assertTrue("Line was not recognised", lineGood.get());
+		assertTrue("Line was not found", foundLine.get());
+		assertFalse("Too many lines", lineError.get());
+	}
+
 }

--- a/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
+++ b/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
@@ -597,7 +597,6 @@ public class CSVStreamTest {
 		assertFalse("Too many lines", lineError.get());
 	}
 
-
 	/**
 	 * Test method for
 	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
@@ -623,6 +622,74 @@ public class CSVStreamTest {
 			return l;
 		}, l -> {
 		}, null, 1);
+
+		assertTrue("Headers were not recognised", headersGood.get());
+		assertTrue("Line was not recognised", lineGood.get());
+		assertTrue("Line was not found", foundLine.get());
+		assertFalse("Too many lines", lineError.get());
+	}
+
+	/**
+	 * Test method for
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
+	 * .
+	 */
+	@Test
+	public final void testStreamCSVCustomQuoteCharacter() throws Exception {
+		
+		AtomicBoolean headersGood = new AtomicBoolean(false);
+		AtomicBoolean lineGood = new AtomicBoolean(false);
+		AtomicBoolean foundLine = new AtomicBoolean(false);
+		AtomicBoolean lineError = new AtomicBoolean(false);
+		CsvMapper mapper = CSVStream.defaultMapper();
+		CsvSchema schema = CsvSchema.builder().setQuoteChar('\'').build();
+		CSVStream.parse(new StringReader("'Test\nHeader1'\n'TestValue1'"), h -> {
+			if (h.size() == 1 && h.contains("Test\nHeader1")) {
+				headersGood.set(true);
+			}
+		}, (h, l) -> {
+			if (foundLine.compareAndSet(false, true) && l.size() == 1 && l.contains("TestValue1")) {
+				lineGood.set(true);
+			} else {
+				lineError.set(true);
+			}
+			return l;
+		}, l -> {
+		}, null, 1, mapper, schema);
+
+		assertTrue("Headers were not recognised", headersGood.get());
+		assertTrue("Line was not recognised", lineGood.get());
+		assertTrue("Line was not found", foundLine.get());
+		assertFalse("Too many lines", lineError.get());
+	}
+
+	/**
+	 * Test method for
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
+	 * .
+	 */
+	@Test
+	public final void testStreamCSVCustomQuoteCharacterInside() throws Exception {
+		
+		AtomicBoolean headersGood = new AtomicBoolean(false);
+		AtomicBoolean lineGood = new AtomicBoolean(false);
+		AtomicBoolean foundLine = new AtomicBoolean(false);
+		AtomicBoolean lineError = new AtomicBoolean(false);
+		CsvMapper mapper = CSVStream.defaultMapper();
+		CsvSchema schema = CsvSchema.builder().setQuoteChar('\'').build();
+		CSVStream.parse(new StringReader("'Test''\nHeader1'\n'TestValue1'"), h -> {
+			if (h.size() == 1 && h.contains("Test'\nHeader1")) {
+				headersGood.set(true);
+			}
+		}, (h, l) -> {
+			if (foundLine.compareAndSet(false, true) && l.size() == 1 && l.contains("TestValue1")) {
+				lineGood.set(true);
+			} else {
+				lineError.set(true);
+			}
+			return l;
+		}, l -> {
+		}, null, 1, mapper, schema);
 
 		assertTrue("Headers were not recognised", headersGood.get());
 		assertTrue("Line was not recognised", lineGood.get());

--- a/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
+++ b/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
@@ -732,4 +732,74 @@ public class CSVStreamTest {
 		assertFalse("Too many lines", lineError.get());
 	}
 
+	/**
+	 * Test method for
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
+	 * .
+	 */
+	@Test
+	public final void testStreamCSVQuoteAndEscapeChanged() throws Exception {
+		
+		AtomicBoolean headersGood = new AtomicBoolean(false);
+		AtomicBoolean lineGood = new AtomicBoolean(false);
+		AtomicBoolean foundLine = new AtomicBoolean(false);
+		AtomicBoolean lineError = new AtomicBoolean(false);
+		// The default mapper skips comment lines
+		CsvMapper mapper = CSVStream.defaultMapper();
+		CsvSchema schema = CsvSchema.builder().setQuoteChar('\'').setEscapeChar('\'').build();
+		CSVStream.parse(new StringReader("'Test''\nHeader1'\n'Test''Value1'"), h -> {
+			if (h.size() == 1 && h.contains("Test'\nHeader1")) {
+				headersGood.set(true);
+			}
+		}, (h, l) -> {
+			if (foundLine.compareAndSet(false, true) && l.size() == 1 && l.contains("Test'Value1")) {
+				lineGood.set(true);
+			} else {
+				lineError.set(true);
+			}
+			return l;
+		}, l -> {
+		}, null, 1, mapper, schema);
+
+		assertTrue("Headers were not recognised", headersGood.get());
+		assertTrue("Line was not recognised", lineGood.get());
+		assertTrue("Line was not found", foundLine.get());
+		assertFalse("Too many lines", lineError.get());
+	}
+
+	/**
+	 * Test method for
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
+	 * .
+	 */
+	@Test
+	public final void testStreamCSVQuoteAndEscapeChangedDifferent() throws Exception {
+		
+		AtomicBoolean headersGood = new AtomicBoolean(false);
+		AtomicBoolean lineGood = new AtomicBoolean(false);
+		AtomicBoolean foundLine = new AtomicBoolean(false);
+		AtomicBoolean lineError = new AtomicBoolean(false);
+		// The default mapper skips comment lines
+		CsvMapper mapper = CSVStream.defaultMapper();
+		CsvSchema schema = CsvSchema.builder().setQuoteChar('\'').setEscapeChar('"').build();
+		CSVStream.parse(new StringReader("'Test\"\"\nHeader1'\n'Test\"\"Value1'"), h -> {
+			if (h.size() == 1 && h.contains("Test\"\nHeader1")) {
+				headersGood.set(true);
+			}
+		}, (h, l) -> {
+			if (foundLine.compareAndSet(false, true) && l.size() == 1 && l.contains("Test\"Value1")) {
+				lineGood.set(true);
+			} else {
+				lineError.set(true);
+			}
+			return l;
+		}, l -> {
+		}, null, 1, mapper, schema);
+
+		assertTrue("Headers were not recognised", headersGood.get());
+		assertTrue("Line was not recognised", lineGood.get());
+		assertTrue("Line was not found", foundLine.get());
+		assertFalse("Too many lines", lineError.get());
+	}
+
 }

--- a/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
+++ b/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
@@ -565,4 +565,36 @@ public class CSVStreamTest {
 		assertFalse("Too many lines", lineError.get());
 	}
 
+	/**
+	 * Test method for
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
+	 * .
+	 */
+	@Test
+	public final void testStreamCSVUnescapedNewLineRFC4180() throws Exception {
+		
+		AtomicBoolean headersGood = new AtomicBoolean(false);
+		AtomicBoolean lineGood = new AtomicBoolean(false);
+		AtomicBoolean foundLine = new AtomicBoolean(false);
+		AtomicBoolean lineError = new AtomicBoolean(false);
+		CSVStream.parse(new StringReader("TestHeader1\n\"Test\nValue1\""), h -> {
+			if (h.size() == 1 && h.contains("TestHeader1")) {
+				headersGood.set(true);
+			}
+		}, (h, l) -> {
+			if (foundLine.compareAndSet(false, true) && l.size() == 1 && l.contains("Test\nValue1")) {
+				lineGood.set(true);
+			} else {
+				lineError.set(true);
+			}
+			return l;
+		}, l -> {
+		}, null, 1);
+
+		assertTrue("Headers were not recognised", headersGood.get());
+		assertTrue("Line was not recognised", lineGood.get());
+		assertTrue("Line was not found", foundLine.get());
+		assertFalse("Too many lines", lineError.get());
+	}
+
 }

--- a/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
+++ b/src/test/java/com/github/ansell/csv/stream/CSVStreamTest.java
@@ -808,7 +808,7 @@ public class CSVStreamTest {
 	 * .
 	 */
 	@Test
-	public final void testStreamTSV() throws Exception {
+	public final void testStreamTSVWithQuoteAndEscape() throws Exception {
 		
 		AtomicBoolean headersGood = new AtomicBoolean(false);
 		AtomicBoolean lineGood = new AtomicBoolean(false);
@@ -823,6 +823,41 @@ public class CSVStreamTest {
 			}
 		}, (h, l) -> {
 			if (foundLine.compareAndSet(false, true) && l.size() == 2 && l.contains("Test\"Value1") && l.contains("TestValue2")) {
+				lineGood.set(true);
+			} else {
+				lineError.set(true);
+			}
+			return l;
+		}, l -> {
+		}, null, 1, mapper, schema);
+
+		assertTrue("Headers were not recognised", headersGood.get());
+		assertTrue("Line was not recognised", lineGood.get());
+		assertTrue("Line was not found", foundLine.get());
+		assertFalse("Too many lines", lineError.get());
+	}
+
+	/**
+	 * Test method for
+	 * {@link com.github.ansell.csv.util.CSVStream#parse(java.io.Reader, java.util.function.Consumer, java.util.function.BiFunction, java.util.function.Consumer, List, int)}
+	 * .
+	 */
+	@Test
+	public final void testStreamTSVNoQuoteOrEscape() throws Exception {
+		
+		AtomicBoolean headersGood = new AtomicBoolean(false);
+		AtomicBoolean lineGood = new AtomicBoolean(false);
+		AtomicBoolean foundLine = new AtomicBoolean(false);
+		AtomicBoolean lineError = new AtomicBoolean(false);
+		// The default mapper skips comment lines
+		CsvMapper mapper = CSVStream.defaultMapper();
+		CsvSchema schema = CsvSchema.builder().disableQuoteChar().disableEscapeChar().setColumnSeparator('\t').build();
+		CSVStream.parse(new StringReader("'Test\\\"Header1'\tTestHeader2\n'Test\\\"Value1'\tTestValue2"), h -> {
+			if (h.size() == 2 && h.contains("'Test\\\"Header1'") && h.contains("TestHeader2")) {
+				headersGood.set(true);
+			}
+		}, (h, l) -> {
+			if (foundLine.compareAndSet(false, true) && l.size() == 2 && l.contains("'Test\\\"Value1'") && l.contains("TestValue2")) {
 				lineGood.set(true);
 			} else {
 				lineError.set(true);


### PR DESCRIPTION
By default, parsing is done with the RFC4180 Section 2 CSV profile. These changes allow users to change the escape, quote, and column characters to match their requirements.

In particular, this is necessary to directly pass settings from DWC archive metadata.xml files through to here. See https://github.com/ansell/dwca-utils/issues/4